### PR TITLE
Add canvas container, external CSS, and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,22 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Queen Tora's Royal Kaleidoscope</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.js"></script>
-
-    <script src="sketch.js"></script>
-
-    <style>
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-        overflow: hidden; /* This stops annoying scrollbars from appearing */
-        background-color: #0a0a19; /* Match your sketch's dark blue (10,10,25) */
-        /* This helps prevent a white flash before the sketch loads */
-      }
-    </style>
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.js"></script>
+    <script defer src="sketch.js"></script>
   </head>
   <body>
-    <main></main>
+    <main>
+      <div id="kaleidoscope-canvas"></div>
+      <div id="controls"></div>
+    </main>
   </body>
 </html>

--- a/sketch.js
+++ b/sketch.js
@@ -1,23 +1,37 @@
 // Kaleidoscope - A gift for Queen Tora!
 
 // Number of symmetrical segments
-let symmetry = 8;
+const symmetry = 8; // default value remains constant
+let segments = symmetry; // actual value controlled by slider
 let angle; // Angle of each segment
 
 let hueValue = 0; // For cycling through colors
 
+let symmetrySlider;
+let strokeSlider;
+
 // To display an initial message
 let hasDrawn = false;
 const instructionText =
-  "Move your mouse to draw patterns!\nClick to clear the canvas.";
+  "Move your mouse to draw patterns!\nClick to clear the canvas.\nUse the sliders to change symmetry and stroke weight.";
 const backgroundColor = [10, 10, 25]; // Royal dark blue background
+
+function resetBackground() {
+  background(backgroundColor[0], backgroundColor[1], backgroundColor[2]);
+}
 
 function setup() {
   // Make the canvas fill the entire window
-  createCanvas(windowWidth, windowHeight);
+  createCanvas(windowWidth, windowHeight).parent('kaleidoscope-canvas');
   angleMode(RADIANS);
-  background(backgroundColor[0], backgroundColor[1], backgroundColor[2]);
-  angle = TWO_PI / symmetry;
+  resetBackground();
+  angle = TWO_PI / segments;
+
+  const controls = select('#controls');
+  createSpan('Symmetry ').parent(controls);
+  symmetrySlider = createSlider(2, 12, segments, 1).parent(controls);
+  createSpan(' Stroke Weight ').parent(controls);
+  strokeSlider = createSlider(1, 12, 10, 0.5).parent(controls);
 
   // Display initial instructions
   displayInitialMessage();
@@ -27,6 +41,7 @@ function displayInitialMessage() {
   push(); // Isolate text drawing settings
   // Ensure text is drawn without being affected by current transformations from draw() if called later
   resetMatrix();
+  resetBackground();
   textAlign(CENTER, CENTER);
   fill(220, 220, 250); // Light lavender text
   noStroke();
@@ -37,6 +52,10 @@ function displayInitialMessage() {
 }
 
 function draw() {
+  segments = symmetrySlider.value();
+  angle = TWO_PI / segments;
+  const maxStroke = strokeSlider.value();
+
   translate(width / 2, height / 2); // Center all drawing operations
 
   if (mouseX > 0 && mouseX < width && mouseY > 0 && mouseY < height) {
@@ -44,7 +63,7 @@ function draw() {
       if (!hasDrawn) {
         push();
         resetMatrix();
-        background(backgroundColor[0], backgroundColor[1], backgroundColor[2]);
+        resetBackground();
         pop();
         hasDrawn = true;
       }
@@ -65,14 +84,14 @@ function draw() {
       saturation = constrain(saturation, 60, 100);
 
       let speed = dist(mx, my, pmx, pmy);
-      let currentStrokeWeight = map(speed, 0, 40, 2, 10);
-      currentStrokeWeight = constrain(currentStrokeWeight, 1.5, 12);
+      let currentStrokeWeight = map(speed, 0, 40, 2, maxStroke);
+      currentStrokeWeight = constrain(currentStrokeWeight, 1.5, maxStroke);
 
       colorMode(HSB, 360, 100, 100, 1.0);
       stroke(hueValue, saturation, 95, 0.65);
       strokeWeight(currentStrokeWeight);
 
-      for (let i = 0; i < symmetry; i++) {
+      for (let i = 0; i < segments; i++) {
         push();
         rotate(i * angle);
         line(mx, my, pmx, pmy);
@@ -89,7 +108,7 @@ function draw() {
 function mousePressed() {
   push();
   resetMatrix();
-  background(backgroundColor[0], backgroundColor[1], backgroundColor[2]);
+  resetBackground();
   pop();
 
   hasDrawn = true; // Drawing will re-commence

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,22 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  overflow: hidden; /* Prevent scrollbars */
+  background-color: #0a0a19; /* Match the sketch background */
+}
+
+#kaleidoscope-canvas {
+  width: 100%;
+  height: 100vh;
+  position: relative;
+}
+
+#controls {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  color: white;
+  z-index: 10;
+  font-family: sans-serif;
+}


### PR DESCRIPTION
## Summary
- move inline styles into a new `styles.css`
- place the canvas in a dedicated container and add a controls panel
- defer script loading
- refactor JS to use resetBackground helper
- add sliders for symmetry and stroke weight

## Testing
- `git status --short`